### PR TITLE
Added buffer mapping

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,37 @@
+# Handle line endings automatically for files detected as text
+# and leave all files detected as binary untouched.
+* text=auto
+
+#
+# The above will handle all files NOT found below
+#
+# These files are text and should be normalized (Convert crlf => lf)
+*.css           text
+*.df            text
+*.htm           text
+*.html          text
+*.java          text    diff=java
+*.js            text
+*.json          text
+*.jsp           text
+*.jspf          text
+*.properties    text
+*.sh            text
+*.svg           text
+*.tld           text
+*.txt           text
+*.xml           text
+
+# These files are binary and should be left untouched
+# (binary is a macro for -text -diff)
+*.class         binary
+*.dll           binary
+*.ear           binary
+*.gif           binary
+*.ico           binary
+*.jar           binary
+*.jpg           binary
+*.jpeg          binary
+*.png           binary
+*.so            binary
+*.war           binary

--- a/.gitignore
+++ b/.gitignore
@@ -3,17 +3,14 @@
 ### Java ###
 *.class
 
-build/
-
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
-
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
 
-### Intellij ###
+### IntelliJ ###
 # Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm
 
 *.iml
@@ -94,6 +91,18 @@ local.properties
 # TeXlipse plugin
 .texlipse
 
+
+### NetBeans ###
+nbproject/private/
+build/
+nbbuild/
+dist/
+nbdist/
+nbactions.xml
+nb-configuration.xml
+.nb-gradle/
+
+
 ### OSX ###
 .DS_Store
 .AppleDouble
@@ -116,3 +125,34 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+
+### Linux ###
+*~
+
+# KDE directory preferences
+.directory
+
+# Linux trash folder which might appear on any partition or disk
+.Trash-*
+
+
+### Windows ###
+# Windows image file caches
+Thumbs.db
+ehthumbs.db
+
+# Folder config file
+Desktop.ini
+
+# Recycle Bin used on file shares
+$RECYCLE.BIN/
+
+# Windows Installer files
+*.cab
+*.msi
+*.msm
+*.msp
+
+# Windows shortcuts
+*.lnk

--- a/src/main/java/com/shc/silenceengine/graphics/opengl/BufferObject.java
+++ b/src/main/java/com/shc/silenceengine/graphics/opengl/BufferObject.java
@@ -30,6 +30,7 @@ import static org.lwjgl.opengl.GL30.*;
  * exists to make the usage of OpenGL functions convenient.
  *
  * @author Sri Harsha Chilakapati
+ * @author Heiko Brumme
  */
 public class BufferObject
 {
@@ -216,6 +217,89 @@ public class BufferObject
     public ByteBuffer getData(ByteBuffer data)
     {
         return getSubData(0, capacity, data);
+    }
+    
+    /**
+     * Maps the buffer object's data store.
+     * 
+     * @param access  The access policy. Valid accesses are READ_ONLY, WRITE_ONLY
+     *                or READ_WRITE.
+     * @param pointer A NIO ByteBuffer used for the data store.
+     * 
+     * @return A pointer to the buffer object's data store as a NIO ByteBuffer.
+     */
+    public ByteBuffer map(int access, ByteBuffer pointer) {
+        bind();
+        pointer = glMapBuffer(target, access, pointer.capacity(), pointer);
+        
+        GLError.check();
+        
+        return pointer;
+    }
+    
+    /**
+     * Maps the buffer object's data store.
+     * 
+     * @param access The access policy. Valid accesses are READ_ONLY, WRITE_ONLY
+     *               or READ_WRITE.
+     * 
+     * @return A pointer to the buffer object's data store as a NIO ByteBuffer.
+     */
+    public ByteBuffer map(int access) {
+        return map(access, BufferUtils.createByteBuffer(capacity));
+    }
+    
+    /**
+     * Maps a section of a buffer object's data store.
+     * 
+     * @param offset  The starting offset within the buffer of the range to be
+     *                mapped.
+     * @param access  Combination of access flags indicating the desired access
+     *                to the range. One or more of: MAP_READ_BIT, MAP_WRITE_BIT,
+     *                MAP_INVALIDATE_RANGE_BIT, MAP_INVALIDATE_BUFFER_BIT,
+     *                MAP_FLUSH_EXPLICIT_BIT, MAP_UNSYNCHRONIZED_BIT.
+     * @param pointer A NIO ByteBuffer used for the data store.
+     * 
+     * @return A pointer to the buffer object's data store as a NIO ByteBuffer.
+     */
+    public ByteBuffer mapRange(long offset, int access, ByteBuffer pointer) {
+        bind();
+        pointer = glMapBufferRange(target, offset, pointer.capacity(), access);
+        
+        GLError.check();
+        
+        return pointer;
+    }
+    
+    /**
+     * Maps a section of a buffer object's data store.
+     * 
+     * @param offset The starting offset within the buffer of the range to be
+     *               mapped.
+     * @param length The length of the range to be mapped.
+     * @param access Combination of access flags indicating the desired access
+     *               to the range. One or more of: MAP_READ_BIT, MAP_WRITE_BIT,
+     *               MAP_INVALIDATE_RANGE_BIT, MAP_INVALIDATE_BUFFER_BIT,
+     *               MAP_FLUSH_EXPLICIT_BIT, MAP_UNSYNCHRONIZED_BIT.
+     * 
+     * @return A pointer to the buffer object's data store as a NIO ByteBuffer.
+     */
+    public ByteBuffer mapRange(long offset, int length, int access) {
+        return mapRange(offset, access, BufferUtils.createByteBuffer(length));
+    }
+    
+    /**
+     * Unmaps the buffer object and invalidates the pointer to its data store.
+     * 
+     * @return Returns true if the unmapping was successful.
+     */
+    public boolean unmap() {
+        bind();
+        boolean unmapped = glUnmapBuffer(target);
+        
+        GLError.check();
+        
+        return unmapped;
     }
 
     /**

--- a/src/main/java/com/shc/silenceengine/tests/ResourceLoaderTest.java
+++ b/src/main/java/com/shc/silenceengine/tests/ResourceLoaderTest.java
@@ -50,11 +50,7 @@ public class ResourceLoaderTest extends Game
     {
         cam.apply();
 
-        batcher.begin();
-        {
-            batcher.drawTexture2d(texture, new Vector2(100, 100));
-        }
-        batcher.end();
+        batcher.drawTexture2d(texture, new Vector2(100, 100));
 
         font1.drawString(batcher, "Times New Roman!!", 10, 10);
         font2.drawString(batcher, "Free Booter Script", 10, 40, Color.GREEN);


### PR DESCRIPTION
According to http://www.gamedev.net/page/resources/_/technical/opengl/opengl-batch-rendering-r3900 you should use glMapBuffer instead of glBufferSubData if moving large chunks of data > 1MB, so the Batcher now can enable buffer mapping. Currently it is disabled by default.
Also added java specific gitattributes, and gitignore now contains NetBeans, Linux and Windows specific files.
Fixed an error in ResourceLoaderTest when testing everything with buffer mapping enabled.