### PR TITLE
Documented shader class

### DIFF
--- a/src/main/java/com/shc/silenceengine/graphics/Batcher.java
+++ b/src/main/java/com/shc/silenceengine/graphics/Batcher.java
@@ -89,10 +89,10 @@ public class Batcher
     public Batcher()
     {
         // Create the buffers
-        vBuffer = BufferUtils.createByteBuffer(SIZE_OF_VERTEX * BATCH_SIZE);
-        cBuffer = BufferUtils.createByteBuffer(SIZE_OF_COLOR * BATCH_SIZE);
-        tBuffer = BufferUtils.createByteBuffer(SIZE_OF_TEXCOORD * BATCH_SIZE);
-        nBuffer = BufferUtils.createByteBuffer(SIZE_OF_NORMAL * BATCH_SIZE);
+        vBuffer = BufferUtils.createByteBuffer(BATCH_SIZE);
+        cBuffer = BufferUtils.createByteBuffer(BATCH_SIZE);
+        tBuffer = BufferUtils.createByteBuffer(BATCH_SIZE);
+        nBuffer = BufferUtils.createByteBuffer(BATCH_SIZE);
 
         // Create the transformations
         transform = new Transform();
@@ -119,19 +119,19 @@ public class Batcher
 
         // Initialize vertex-buffer
         vboVert.bind();
-        vboVert.uploadData(SIZE_OF_VERTEX * BATCH_SIZE, GL_STREAM_DRAW);
+        vboVert.uploadData(BATCH_SIZE, GL_STREAM_DRAW);
 
         // Initialize color-buffer
         vboCol.bind();
-        vboCol.uploadData(SIZE_OF_COLOR * BATCH_SIZE, GL_STREAM_DRAW);
+        vboCol.uploadData(BATCH_SIZE, GL_STREAM_DRAW);
 
         // Initialize texcoord-buffer
         vboTex.bind();
-        vboTex.uploadData(SIZE_OF_TEXCOORD * BATCH_SIZE, GL_STREAM_DRAW);
+        vboTex.uploadData(BATCH_SIZE, GL_STREAM_DRAW);
 
         // Initialize normal-buffer
         vboNorm.bind();
-        vboNorm.uploadData(SIZE_OF_NORMAL * BATCH_SIZE, GL_STREAM_DRAW);
+        vboNorm.uploadData(BATCH_SIZE, GL_STREAM_DRAW);
     }
     
     /**
@@ -140,16 +140,16 @@ public class Batcher
     private void mapBuffers()
     {
         vBuffer = vboVert.map(GL_WRITE_ONLY, vBuffer);
-        vao.pointAttribute(vertexLocation, 4, GL_FLOAT, vboVert);
+        vao.pointAttribute(vertexLocation, SIZE_OF_VERTEX, GL_FLOAT, vboVert);
 
         cBuffer = vboCol.map(GL_WRITE_ONLY, cBuffer);
-        vao.pointAttribute(colorLocation, 4, GL_FLOAT, vboCol);
+        vao.pointAttribute(colorLocation, SIZE_OF_COLOR, GL_FLOAT, vboCol);
 
         tBuffer = vboTex.map(GL_WRITE_ONLY, tBuffer);
-        vao.pointAttribute(texCoordLocation, 2, GL_FLOAT, vboTex);
+        vao.pointAttribute(texCoordLocation, SIZE_OF_TEXCOORD, GL_FLOAT, vboTex);
 
         nBuffer = vboNorm.map(GL_WRITE_ONLY, nBuffer);
-        vao.pointAttribute(normalLocation, 4, GL_FLOAT, vboNorm);
+        vao.pointAttribute(normalLocation, SIZE_OF_NORMAL, GL_FLOAT, vboNorm);
     }
     
     /**

--- a/src/main/java/com/shc/silenceengine/graphics/opengl/Shader.java
+++ b/src/main/java/com/shc/silenceengine/graphics/opengl/Shader.java
@@ -7,21 +7,32 @@ import static org.lwjgl.opengl.GL20.*;
  * Encapsulates OpenGL Shader objects nicely in a Java Wrapper making
  * it easy to use in an object oriented way.
  *
- * TODO: Document this class and its methods.
- *
  * @author Sri Harsha Chilakapati
+ * @author Heiko Brumme
  */
 public class Shader
 {
     private int     id;
     private boolean disposed;
 
+    /**
+     * Creates a shader with a specified type. Valid types are GL_VERTEX_SHADER,
+     * GL_GEOMETRY_SHADER or GL_FRAGMENT_SHADER.
+     * 
+     * @param type The type of this shader
+     */
     public Shader(int type)
     {
         id = glCreateShader(type);
         GLError.check();
     }
 
+    /**
+     * Sets the source code for this shader. Any source code previously stored
+     * in the shader object is completely replaced.
+     * 
+     * @param source The source code for this shader
+     */
     public void source(String source)
     {
         if (disposed)
@@ -31,6 +42,9 @@ public class Shader
         GLError.check();
     }
 
+    /**
+     * Compiles the shader and checks its compile status afterwards.
+     */
     public void compile()
     {
         if (disposed)
@@ -43,6 +57,11 @@ public class Shader
             throw new GLException("Unable to compile shader:\n" + getInfoLog());
     }
 
+    /**
+     * Returns the information log for a shader object.
+     * 
+     * @return Information log for this shader
+     */
     public String getInfoLog()
     {
         if (disposed)
@@ -51,6 +70,9 @@ public class Shader
         return glGetShaderInfoLog(id);
     }
 
+    /**
+     * Disposes the shader. You can't use the shader after disposing.
+     */
     public void dispose()
     {
         glDeleteShader(id);
@@ -58,11 +80,22 @@ public class Shader
         disposed = true;
     }
 
+    /**
+     * Tells if the shader is disposed.
+     * 
+     * @return True if this Shader is disposed, else it returns false
+     */
     public boolean isDisposed()
     {
         return disposed;
     }
 
+    /**
+     * Gets the ID of the shader.
+     * 
+     * @return The ID of this Shader. Useful if you directly
+     *         want to use any OpenGL function yourself.
+     */
     public int getId()
     {
         return id;


### PR DESCRIPTION
Documented shader class.
The batches should now have a size of 4 MB.
The attribute pointers are now using the private constants SIZE_OF_VERTEX, SIZE_OF_NORMAL, SIZE_OF_COLOR and SIZE_OF_TEXCOORD instead of hard-coded values.