### PR TITLE
Allows the Cursor to be set from the Display #10

### DIFF
--- a/src/main/java/com/shc/silenceengine/core/Display.java
+++ b/src/main/java/com/shc/silenceengine/core/Display.java
@@ -211,7 +211,7 @@ public final class Display
     
     public static void setCursor(Cursor cursor)
     {
-    	if (displayWindow == null)
+        if (displayWindow == null)
             return;
 
         displayWindow.setCursor(cursor);

--- a/src/main/java/com/shc/silenceengine/core/Display.java
+++ b/src/main/java/com/shc/silenceengine/core/Display.java
@@ -24,6 +24,7 @@
 
 package com.shc.silenceengine.core;
 
+import com.shc.silenceengine.core.glfw.Cursor;
 import com.shc.silenceengine.core.glfw.GLFW3;
 import com.shc.silenceengine.core.glfw.Monitor;
 import com.shc.silenceengine.core.glfw.VideoMode;
@@ -206,6 +207,14 @@ public final class Display
             return;
 
         displayWindow.setInputMode(GLFW_CURSOR, GLFW_CURSOR_NORMAL);
+    }
+    
+    public static void setCursor(Cursor cursor)
+    {
+    	if (displayWindow == null)
+            return;
+
+        displayWindow.setCursor(cursor);
     }
 
     public static void destroy()


### PR DESCRIPTION
implements Suggestion #10 and allows for the cursor to be set directly from the `Display` class and not needing to use `Display.getWindow().setCursor(Cursor);`