### PR TITLE
Build script now includes logo_dark.png

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,4 +37,5 @@ jar {
     include("resources/**.vert")
     include("resources/**.glsl")
     include("resources/logo.png")
+    include("resources/logo_dark.png")
 }


### PR DESCRIPTION
This fixes the ResourceLoader crash when running using compiled jar