### PR TITLE
Added the file path to the file not found exceptions.

### DIFF
--- a/src/main/java/com/shc/silenceengine/io/FilePath.java
+++ b/src/main/java/com/shc/silenceengine/io/FilePath.java
@@ -313,10 +313,10 @@ public class FilePath
     public InputStream getInputStream() throws IOException
     {
         if (isDirectory())
-            throw new SilenceException("Cannot read from a directory.");
+            throw new SilenceException("Cannot read from a directory. " + path);
 
         if (!exists())
-            throw new SilenceException("Cannot read from a non existing file.");
+            throw new SilenceException("Cannot read from a non existing file. " + path);
 
         InputStream inputStream = null;
 


### PR DESCRIPTION
This change adds the file path to the exception. The current implementation of this exception does not print the file path. This can make it very tedious to track down missing files, especially if you are loading a lot of files, The exception does not give you a line number, or any other relevant information to go off of.