### PR TITLE
Fix leading / being removed from jar paths

### DIFF
--- a/src/main/java/com/shc/silenceengine/backend/lwjgl3/io/Lwjgl3ResourceFilePath.java
+++ b/src/main/java/com/shc/silenceengine/backend/lwjgl3/io/Lwjgl3ResourceFilePath.java
@@ -247,7 +247,7 @@ public class Lwjgl3ResourceFilePath extends FilePath
             throw new SilenceException("Error, resource doesn't exist.");
 
         String jarUrl = url.toString();
-        String jarPath = URLDecoder.decode(jarUrl.substring(jarUrl.indexOf('/') + 1, jarUrl.indexOf('!')), "UTF-8");
+        String jarPath = URLDecoder.decode(jarUrl.substring(jarUrl.indexOf('/'), jarUrl.indexOf('!')), "UTF-8");
 
         // Now get the JarEntry for this path
         JarFile jarFile = new JarFile(new File(jarPath));


### PR DESCRIPTION
Previously the missing `/` caused a crash because the jar files could not be located.

Without the leading slash, Java (at least on OS X) presumes the path is starting at `.` or the run directory.