### PR TITLE
Updating the rotateX for FPSCamera

### DIFF
--- a/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
+++ b/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
@@ -140,17 +140,14 @@ public class FPSCamera extends BaseCamera
 
     public FPSCamera rotateX(float angle)
     {
-        // If the current angle is already on the limit, do nothing.
-        if (angleX <= -ANGLE_LIMIT_X || angleX >= ANGLE_LIMIT_X) {
+        if ( (angleX <= -ANGLE_LIMIT_X) && (angle < 0) ||
+                (angleX >= ANGLE_LIMIT_X) && (angle > 0) ) {
             return this;
         }
-        
+
         angleX += angle;
 
-        // the limit was exceeded by this new rotation...
-        // We need to calculate which angle is needed to obtain the limit
-        if (angleX < -ANGLE_LIMIT_X || angleX > ANGLE_LIMIT_X)
-        {
+        if (angleX < -ANGLE_LIMIT_X || angleX > ANGLE_LIMIT_X) {
             float deltaAngle = (angleX < 0 ? angleX + ANGLE_LIMIT_X : angleX - ANGLE_LIMIT_X) * -1.f;
             angleX = (angleX < 0 ? -ANGLE_LIMIT_X : ANGLE_LIMIT_X);
             angle -= deltaAngle;

--- a/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
+++ b/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
@@ -34,6 +34,7 @@ import org.lwjgl.opengl.GL11;
 
 /**
  * @author Sri Harsha Chilakapati
+ * @author Kevin Beaucoral
  */
 public class FPSCamera extends BaseCamera
 {

--- a/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
+++ b/src/main/java/com/shc/silenceengine/graphics/cameras/FPSCamera.java
@@ -139,13 +139,20 @@ public class FPSCamera extends BaseCamera
 
     public FPSCamera rotateX(float angle)
     {
+        // If the current angle is already on the limit, do nothing.
+        if (angleX <= -ANGLE_LIMIT_X || angleX >= ANGLE_LIMIT_X) {
+            return this;
+        }
+        
         angleX += angle;
 
-        // Limit rotation on the X-axis to make it work like an FPSCamera
+        // the limit was exceeded by this new rotation...
+        // We need to calculate which angle is needed to obtain the limit
         if (angleX < -ANGLE_LIMIT_X || angleX > ANGLE_LIMIT_X)
         {
-            angleX -= angle;
-            return this;
+            float deltaAngle = (angleX < 0 ? angleX + ANGLE_LIMIT_X : angleX - ANGLE_LIMIT_X) * -1.f;
+            angleX = (angleX < 0 ? -ANGLE_LIMIT_X : ANGLE_LIMIT_X);
+            angle -= deltaAngle;
         }
 
         Quaternion tempQuat = Quaternion.REUSABLE_STACK.pop();


### PR DESCRIPTION
If you just return this without doing no angle rotation when the FPSCamera isn't already in ANGLE_LIMIT_X it can never obtain the limit.
Exemple : 
FPSCamera are in angleX 50.9, if the angleX in parameter for this update is more than 1.1 (lag, speed etc affect this angleX) the FPSCamera will never obtain the max angle X.

So we need to calculate which angle is needed to obtain the limite when a rotation exceeds it.
